### PR TITLE
Fix first alarm sound

### DIFF
--- a/__tests__/TimerSoundApp.test.tsx
+++ b/__tests__/TimerSoundApp.test.tsx
@@ -195,4 +195,21 @@ describe("TimerSoundApp", () => {
     expect(screen.getByText(/elapsed: 1s/i)).toBeInTheDocument();
     jest.useRealTimers();
   });
+
+  it("plays the first sound trigger", () => {
+    jest.useFakeTimers();
+    const playMock = jest.fn();
+    (global.Audio as jest.Mock).mockImplementation(() => ({ play: playMock }));
+    render(<TimerSoundApp />);
+    fireEvent.click(screen.getByRole("button", { name: /add sound/i }));
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "/sounds/ding.wav" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /start/i }));
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(playMock).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -167,8 +167,7 @@ export default function TimerSoundApp() {
     setRunning(true);
     intervalRef.current = setInterval(() => {
       setCurrentSecond((prev) => {
-        if (prev === null) return 0;
-        const next = prev + 1;
+        const next = (prev ?? 0) + 1;
         // Play any sound scheduled for this second
         sounds.forEach((s) => {
           if (s.second === next && s.src) {


### PR DESCRIPTION
## Summary
- ensure timer uses previous state when schedule hasn't started yet
- verify first sound trigger plays

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68455daaf8f08333a51013e2740853e6