### PR TITLE
Persist custom audio with IndexedDB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@vercel/analytics": "^1.5.0",
+        "idb": "^8.0.3",
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -5569,6 +5570,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "@vercel/analytics": "^1.5.0",
     "next": "15.3.3",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "idb": "^8.0.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/idb.ts
+++ b/src/idb.ts
@@ -1,0 +1,38 @@
+import { openDB } from 'idb';
+
+const DB_NAME = 'freedive-timer';
+const STORE_NAME = 'custom-sounds';
+const DB_VERSION = 1;
+
+export type StoredSound = {
+  name: string;
+  blob: Blob;
+};
+
+const dbPromise = openDB(DB_NAME, DB_VERSION, {
+  upgrade(db) {
+    if (!db.objectStoreNames.contains(STORE_NAME)) {
+      db.createObjectStore(STORE_NAME);
+    }
+  },
+});
+
+export async function saveSound(id: string, data: StoredSound) {
+  const db = await dbPromise;
+  await db.put(STORE_NAME, data, id);
+}
+
+export async function getSound(id: string): Promise<StoredSound | undefined> {
+  const db = await dbPromise;
+  return (await db.get(STORE_NAME, id)) as StoredSound | undefined;
+}
+
+export async function deleteSound(id: string) {
+  const db = await dbPromise;
+  await db.delete(STORE_NAME, id);
+}
+
+export async function listSoundIds(): Promise<IDBValidKey[]> {
+  const db = await dbPromise;
+  return db.getAllKeys(STORE_NAME);
+}


### PR DESCRIPTION
## Summary
- add `idb` for IndexedDB helpers
- persist uploaded sound files into IndexedDB
- load custom sounds from IndexedDB on startup
- mock db module in tests and add coverage for persistence

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6845836929e08333a9e6a2b977f2913d